### PR TITLE
fix: surface doc parse failures instead of empty success

### DIFF
--- a/internal/app/godoc.go
+++ b/internal/app/godoc.go
@@ -103,7 +103,13 @@ func ReadGoDocPaged(
 
 		// If no documentation found, try to parse the README section
 		if !matched {
-			_, parsedDoc = parseReadme(doc)
+			matched, parsedDoc = parseReadme(doc)
+		}
+
+		// Nothing parsed: treat as not found instead of caching and returning
+		// an empty document, which would mask pkg.go.dev markup drift.
+		if !matched || strings.TrimSpace(parsedDoc) == "" {
+			return "", 0, false, ErrNotFound
 		}
 
 		document = parsedDoc
@@ -178,7 +184,13 @@ func SearchWithinGoDoc(
 
 		// If no documentation found, try to parse the README section
 		if !matched {
-			_, parsedDoc = parseReadme(doc)
+			matched, parsedDoc = parseReadme(doc)
+		}
+
+		// Nothing parsed: treat as not found instead of caching and returning
+		// an empty document, which would mask pkg.go.dev markup drift.
+		if !matched || strings.TrimSpace(parsedDoc) == "" {
+			return nil, ErrNotFound
 		}
 
 		document = parsedDoc

--- a/internal/app/pydoc.go
+++ b/internal/app/pydoc.go
@@ -103,7 +103,13 @@ func ReadPyDocPaged(
 			return "", 0, false, errors.Wrap(err, "failed to parse HTML")
 		}
 
-		_, document = parsePyDocPage(doc)
+		matched, parsed := parsePyDocPage(doc)
+		// Nothing parsed: treat as not found instead of caching and returning
+		// an empty document, which would mask docs.python.org markup drift.
+		if !matched || strings.TrimSpace(parsed) == "" {
+			return "", 0, false, ErrNotFound
+		}
+		document = parsed
 
 		docCache.Set(cacheKey, document, cache.DefaultExpiration)
 	}
@@ -161,7 +167,13 @@ func SearchWithinPyDoc(
 			return nil, errors.Wrap(err, "failed to parse HTML")
 		}
 
-		_, document = parsePyDocPage(doc)
+		matched, parsed := parsePyDocPage(doc)
+		// Nothing parsed: treat as not found instead of caching and returning
+		// an empty document, which would mask docs.python.org markup drift.
+		if !matched || strings.TrimSpace(parsed) == "" {
+			return nil, ErrNotFound
+		}
+		document = parsed
 
 		docCache.Set(cacheKey, document, cache.DefaultExpiration)
 	}

--- a/internal/app/rustdoc.go
+++ b/internal/app/rustdoc.go
@@ -71,7 +71,13 @@ func ReadRustDocPaged(
 			return "", 0, false, errors.Wrap(err, "failed to parse HTML")
 		}
 
-		_, document = parseDocsRsDocument(doc)
+		matched, parsed := parseDocsRsDocument(doc)
+		// Nothing parsed: treat as not found instead of caching and returning
+		// an empty document, which would mask docs.rs markup drift.
+		if !matched || strings.TrimSpace(parsed) == "" {
+			return "", 0, false, ErrNotFound
+		}
+		document = parsed
 
 		docCache.Set(cacheKey, document, cache.DefaultExpiration)
 	}
@@ -129,7 +135,13 @@ func SearchWithinRustDoc(
 			return nil, errors.Wrap(err, "failed to parse HTML")
 		}
 
-		_, document = parseDocsRsDocument(doc)
+		matched, parsed := parseDocsRsDocument(doc)
+		// Nothing parsed: treat as not found instead of caching and returning
+		// an empty document, which would mask docs.rs markup drift.
+		if !matched || strings.TrimSpace(parsed) == "" {
+			return nil, ErrNotFound
+		}
+		document = parsed
 
 		docCache.Set(cacheKey, document, cache.DefaultExpiration)
 	}


### PR DESCRIPTION
## Summary
Fixes the two robustness gaps found while verifying the dq-based parsers against live pkg.go.dev. The same pattern existed in all three doc readers (godoc, rustdoc, pydoc).

## The problems
In `Read*Paged` and `SearchWithin*`:
1. **Silent empty on parse failure** — the parser's `matched` flag was discarded (`_, document = parse...`). When all parsers missed (e.g. the site renamed a CSS class), the reader returned `""` with a `nil` error, indistinguishable from "this package has no docs."
2. **Caching failures** — `docCache.Set` ran even for an empty document, poisoning the cache for the 30-minute TTL on a transient miss or markup drift.

These matter because the parsers are CSS-class-coupled and the golden tests run against **saved** HTML, so they can't catch live drift — the failure mode was silent empty output.

## The fix
`Read*Paged` / `SearchWithin*` now check the parse result and return `ErrNotFound` when nothing matched (or the parsed document is blank), and only cache non-empty parses. Applied consistently across `godoc.go`, `rustdoc.go`, `pydoc.go` (6 call sites).

```go
matched, parsed := parseDocsRsDocument(doc)
if !matched || strings.TrimSpace(parsed) == "" {
    return "", 0, false, ErrNotFound
}
document = parsed
docCache.Set(cacheKey, document, cache.DefaultExpiration)
```

(godoc keeps its `parseDocument` → `parseReadme` fallback; the guard runs after both.)

## Verification
- `go build`, `go vet`, full `go test` ✅
- `make lint` → 0 issues
- Golden tests unaffected (they exercise `parse*` directly, not the readers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)