### PR TITLE
build: ensure macOS mcpb binary keeps the executable bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ mcpb-build: ## Cross-compile binaries for the MCPB bundle (macOS universal + Win
 	lipo -create -output mcpb/server/godevmcp-darwin mcpb/server/godevmcp-darwin-arm64 mcpb/server/godevmcp-darwin-amd64
 	rm -f mcpb/server/godevmcp-darwin-arm64 mcpb/server/godevmcp-darwin-amd64
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o mcpb/server/godevmcp-win32.exe godevmcp/main.go
+	# Ensure the executable bit is set so mcpb pack stores it in the archive;
+	# Claude Desktop requires the extracted macOS server binary to be executable.
+	chmod +x mcpb/server/godevmcp-darwin
 
 mcpb-pack: mcpb-build ## Build binaries and pack the .mcpb bundle
 	mkdir -p output


### PR DESCRIPTION
## Summary
Guarantees the bundled macOS server binary is executable inside the `.mcpb`, so Claude Desktop can launch it.

## Why
`mcpb pack` stores each source file's unix mode in the zip, so the extracted binary is only executable if the file had `+x` at pack time. `go build`/`lipo` currently produce `+x`, but this makes it explicit and robust on the CI runner rather than relying on toolchain defaults.

```make
chmod +x mcpb/server/godevmcp-darwin
```

Verified the packed archive stores `rwxr-xr-x` for `server/godevmcp-darwin` (via `zipinfo`). The Windows `.exe` doesn't need a unix executable bit, so it's left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)