### PR TITLE
ci: adopt klein-cli AI review workflow

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,24 @@
+# AI code review, delegated to klein-cli's reusable workflow.
+#
+# Trust model: this uses `on: pull_request` (NOT pull_request_target) and the
+# job is gated to same-repository branches below, so the API-key secret is only
+# ever exposed to code from contributors who already have push access. Fork PRs
+# get no secrets and are skipped.
+name: AI Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: fpt/klein-cli/.github/workflows/ai-review-reusable.yml@main
+    with:
+      language: en
+    secrets:
+      openai-api-key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary
Adopt klein-cli's AI code-review workflow by delegating to its published reusable workflow (`fpt/klein-cli/.github/workflows/ai-review-reusable.yml@main`).

On every PR (`opened`/`synchronize`/`reopened`) it runs `klein review` over the diff and posts a single sticky summary comment plus inline review comments. Reviews are stateful — incremental on later pushes, no-op rebases skipped, verified-fixed threads resolved.

- Backend: `openai`, language: `en`
- Gated to same-repo PRs (`head.repo.full_name == github.repository`), so fork PRs are skipped and never see the API-key secret.

## Setup required
Add the `OPENAI_API_KEY` secret to the repo for the workflow to run:

```
gh secret set OPENAI_API_KEY --repo fpt/go-dev-mcp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)