### PR TITLE
ci(ai-review): grant contents: write so the AI review can start

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -10,8 +10,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+# `contents: write` is not used to push anything — the review writes no code.
+# GitHub gates the `resolveReviewThread` GraphQL mutation on it (not on
+# `pull-requests: write`, as one would expect), and the reusable workflow now
+# resolves threads the reviewer has verified as fixed. It has to be granted
+# here because a reusable workflow can only narrow the permissions it inherits;
+# inside it, the job that checks out and runs this PR's code is narrowed back
+# to `contents: read`, so no job holds both a write token and PR-authored code.
+# See fpt/klein-cli#111.
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
The AI review has been failing at startup here since fpt/klein-cli#112 merged —
`startup_failure`, no jobs, no review.

That PR split thread resolution into its own job holding `contents: write`, the
permission GitHub actually gates `resolveReviewThread` on. A called workflow may
only *narrow* the permissions it inherits, so a job requesting more than the
caller granted isn't a degraded feature — it's a parse-time rejection that stops
the entire workflow. This repo grants `contents: read`, so nothing ran.

Granting the ceiling here fixes it. Nothing writes to this repository: inside the
reusable workflow the job that checks out and runs this repo's PR code is
narrowed straight back to `contents: read`, and only the mutation-only job —
no checkout, no build, no model — keeps the write scope.

Upstream: fpt/klein-cli#111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
